### PR TITLE
Update validation.php

### DIFF
--- a/de/validation.php
+++ b/de/validation.php
@@ -46,7 +46,7 @@ return array(
     "min"              => array(
         "numeric" => ":attribute muss gr&ouml;&szlig;er als :min sein.",
         "file"    => ":attribute muss gr&ouml;&szlig;er als :min Kilobytes gro&szlig; sein.",
-        "string"  => ":attribute muss l&auml;nger als :min Zeichen sein.",
+        "string"  => ":attribute muss mindestens :min Zeichen lang sein.",
     ),
     "not_in"           => "Der gew&auml;hlte Wert f&uuml;r :attribute ist ung&uuml;ltig.",
     "numeric"          => ":attribute muss eine Zahl sein.",


### PR DESCRIPTION
Fixed typo.
Consider this validation rule:
'password'  => 'min:8'

before:

password muss länger als 8 Zeichen sein // the information provided here is wrong, not > 8, but >= 8

now:

password muss mindestens 8 Zeichen lang sein
