### PR TITLE
Removed 'amount' from validation.php

### DIFF
--- a/src/nl/validation.php
+++ b/src/nl/validation.php
@@ -143,7 +143,6 @@ return [
     'attributes' => [
         'address'               => 'adres',
         'age'                   => 'leeftijd',
-        'amount'                => 'bedrag',
         'available'             => 'beschikbaar',
         'city'                  => 'stad',
         'content'               => 'inhoud',


### PR DESCRIPTION
Removed the Dutch translation for 'amount' since this is only one possible meaning and a specific one. This translation is 'the amount of money' or 'price'. A better translation for the general form/meaning of 'amount' would be 'hoeveelheid'. Since this word isn't it other language files (checked FR, DE and the English source), I recommend to remove it to avoid confusion.