### PR TITLE
[hu] Fix exists validation message

### DIFF
--- a/src/hu/validation.php
+++ b/src/hu/validation.php
@@ -40,7 +40,7 @@ return [
     'distinct'       => 'A(z) :attribute értékének egyedinek kell lennie!',
     'email'          => 'A(z) :attribute nem érvényes email formátum.',
     'ends_with'      => 'A(z) :attribute a következővel kell végződjön: :values',
-    'exists'         => 'A(z) :attribute már létezik.',
+    'exists'         => 'A kiválasztott :attribute érvénytelen.',
     'file'           => 'A(z) :attribute fájl kell, hogy legyen!',
     'filled'         => 'A(z) :attribute megadása kötelező!',
     'gt'             => [


### PR DESCRIPTION
Hi,

Currently, the validation message for the "exists" rule is wrong in hungarian.
The original message is: "The selected :attribute is invalid."
The current translation means: "The :attribute exists."

Correctly, it should be "A kiválasztott :attribute érvénytelen."
"kiválasztott" means selected
"érvénytelen" means invalid
