### PR TITLE
Auto-make todo.md

### DIFF
--- a/.github/workflows/make-todo.yml
+++ b/.github/workflows/make-todo.yml
@@ -1,0 +1,42 @@
+name: make-todo
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: true
+
+        name: Make TODO.md
+
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v2
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v1
+                with:
+                    php-version: 7.4
+                    extensions: mbstring, json
+
+            -   name: Git setup
+                run: |
+                    git config --local user.email "action@github.com"
+                    git config --local user.name "GitHub Action"
+
+            -   name: Generate todo.md
+                run: php script/todo.php
+
+            -   name: Commit file
+                run: |
+                    git add .
+                    git commit -a -m "Updated todo.md file"
+
+            -   name: Push changes
+                uses: ad-m/github-push-action@master
+                with:
+                    github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/script/todo.php
+++ b/script/todo.php
@@ -27,7 +27,6 @@ class Storage
 
     public function store(string $path, string $content): void
     {
-        $path = $this->realpath($path);
         file_put_contents($path, $content);
     }
 


### PR DESCRIPTION
Recently, I have been seeing a problem with the todo.md file conflict.

I propose a solution to the problem: when creating a PR, developers DO NOT add the todo.md file to it.

When a PR is accepted into the master branch, the "GitHub Action" is launched, which itself generates this file and pushes to master.

All you need to do in this repository is to check if GitHub Actions are enabled.

For example,
![image](https://user-images.githubusercontent.com/10347617/95314727-504ad780-089a-11eb-91fe-a1b01425ee2b.png)

If the developer adds a modified todo.md file to the PR, then it's okay. There will be two options:
1. If there is no PR conflict, then it can be accepted;
2. If there is a conflict, the developer will have to solve it.

In any case, the file will be automatically updated when a PR is merged or a push to the master branch.