### PR TITLE
[sl] Updated 2 missing translations

### DIFF
--- a/json/sl.json
+++ b/json/sl.json
@@ -45,7 +45,7 @@
     "Editor users have the ability to read, create, and update.": "Uredniki imajo možnost branja, kreairanja in posodabljanja.",
     "Editor": "Urednik",
     "Email Password Reset Link": "Pošlji povezavo za ponastavitev gesla na e-mail",
-    "Email": "Email",
+    "Email": "Elektronski naslov",
     "Enable": "Omogoči",
     "Ensure your account is using a long, random password to stay secure.": "Za boljšo varnost računa naj bo geslo dolgo in naključno.",
     "For your security, please confirm your password to continue.": "Zaradi varnosti pred nadaljevanjem potrdite geslo.",

--- a/script/excludes/sl.php
+++ b/script/excludes/sl.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Exclusion list
+    |--------------------------------------------------------------------------
+    |
+    | This is a list of exclusions for words or phrases where the original
+    | form of the word has the same spelling in a given language.
+    |
+    */
+
+    'Administrator',
+];


### PR DESCRIPTION
'Email' changed to 'Elektronski naslov' (both are ok in sl)
Added 'Administrator' to exclusion list

'todo' file has to be updated by somebody else. Thank you.