### PR TITLE
[en, es] Add missing tags related to button's labels for mail - team …

### DIFF
--- a/json/es.json
+++ b/json/es.json
@@ -1,6 +1,7 @@
 {
     "A fresh verification link has been sent to your email address.": "Se ha enviado un nuevo enlace de verificación a su correo electrónico.",
     "A new verification link has been sent to the email address you provided during registration.": "Se ha enviado un nuevo enlace de verificación a la dirección de correo electrónico que proporcionó durante el registro.",
+    "Accept Invitation": "Aceptar invitación",
     "Add": "Agregar",
     "Add a new team member to your team, allowing them to collaborate with you.": "Agregue un nuevo miembro a su equipo, lo que le permitirá colaborar con usted.",
     "Add additional security to your account using two factor authentication.": "Agregue seguridad adicional a su cuenta mediante la autenticación de dos factores.",
@@ -29,6 +30,7 @@
     "Confirm Password": "Confirmar contraseña",
     "Create": "Crear",
     "Create a new team to collaborate with others on projects.": "Cree un nuevo equipo para colaborar con otros en proyectos.",
+    "Create Account": "Crear cuenta",
     "Create API Token": "Crear Token API",
     "Create New Team": "Crear nuevo equipo",
     "Create Team": "Crear equipo",

--- a/script/en/en.json
+++ b/script/en/en.json
@@ -1,6 +1,7 @@
 {
     "A fresh verification link has been sent to your email address.": "A fresh verification link has been sent to your email address.",
     "A new verification link has been sent to the email address you provided during registration.": "A new verification link has been sent to the email address you provided during registration.",
+    "Accept Invitation": "Accept Invitation",
     "Add a new team member to your team, allowing them to collaborate with you.": "Add a new team member to your team, allowing them to collaborate with you.",
     "Add additional security to your account using two factor authentication.": "Add additional security to your account using two factor authentication.",
     "Add Team Member": "Add Team Member",
@@ -28,6 +29,7 @@
     "Confirm Password": "Confirm Password",
     "Confirm": "Confirm",
     "Create a new team to collaborate with others on projects.": "Create a new team to collaborate with others on projects.",
+    "Create Account": "Create Account",
     "Create API Token": "Create API Token",
     "Create New Team": "Create New Team",
     "Create Team": "Create Team",

--- a/src/es/validation.php
+++ b/src/es/validation.php
@@ -174,6 +174,7 @@ return [
         'password_confirmation' => 'confirmación de la contraseña',
         'phone'                 => 'teléfono',
         'price'                 => 'precio',
+        'role'                  => 'rol',
         'second'                => 'segundo',
         'sex'                   => 'sexo',
         'subject'               => 'asunto',


### PR DESCRIPTION
Button's labels in the mail template for team invitations are pending to translate

- [Create Account](https://github.com/laravel/jetstream/blob/2.x/resources/views/mail/team-invitation.blade.php#L7)
- [Accept Invitation](https://github.com/laravel/jetstream/blob/2.x/resources/views/mail/team-invitation.blade.php#L13)

