### PR TITLE
[en, es] Translate subject of Team Invitation email

### DIFF
--- a/json/es.json
+++ b/json/es.json
@@ -141,6 +141,7 @@
     "Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.": "Guarde estos códigos de recuperación en un administrador de contraseñas seguro. Se pueden utilizar para recuperar el acceso a su cuenta si pierde su dispositivo de autenticación de dos factores.",
     "Switch Teams": "Cambiar de equipo",
     "Team Details": "Detalles del equipo",
+    "Team Invitation": "Invitación de equipo",
     "Team Members": "Miembros del equipo",
     "Team Name": "Nombre del equipo",
     "Team Owner": "Propietario del equipo",

--- a/script/en/en.json
+++ b/script/en/en.json
@@ -132,6 +132,7 @@
     "Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.": "Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.",
     "Switch Teams": "Switch Teams",
     "Team Details": "Team Details",
+    "Team Invitation": "Team Invitation",
     "Team Members": "Team Members",
     "Team Name": "Team Name",
     "Team Owner": "Team Owner",


### PR DESCRIPTION
I made a [Pull Request](https://github.com/laravel/jetstream/pull/625) to [Laravel Jetstream](https://github.com/laravel/jetstream) in order to *Make the subject of the team invitation email translatable* which was ***merged***.

- [Team Invitation](https://github.com/laravel/jetstream/blob/2.x/src/Mail/TeamInvitation.php#L42)