### PR TITLE
[es] Add tag for retrocompatibility

### DIFF
--- a/json/es.json
+++ b/json/es.json
@@ -126,6 +126,7 @@
     "Please enter your password to confirm you would like to log out of your other browser sessions across all of your devices.": "Por favor ingrese su contraseña para confirmar que desea cerrar las demás sesiones de otros navegadores en todos sus dispositivos.",
     "Please enter your password to confirm you would like to logout of your other browser sessions across all of your devices.": "Por favor ingrese su contraseña para confirmar que desea cerrar las demás sesiones de otros navegadores en todos sus dispositivos.",
     "Please provide the email address of the person you would like to add to this team.": "Por favor proporcione la dirección de correo electrónico de la persona que le gustaría agregar a este equipo.",
+    "Please provide the email address of the person you would like to add to this team. The email address must be associated with an existing account.": "Por favor proporcione la dirección de correo electrónico de la persona que le gustaría agregar a este equipo. La dirección de correo electrónico debe estar asociada a una cuenta existente.",
     "Please provide your name.": "Por favor proporcione su nombre.",
     "Privacy Policy": "Política de Privacidad",
     "Profile": "Perfil",


### PR DESCRIPTION
I added this tag for possible backward compatibility with Laravel Jetstream (version < 2) and for not damaging the _completion status_ of the Spanish language. But I must clarify that this tag doesn't exist in **Laravel Jetstream** v2, it [was removed](https://github.com/laravel/jetstream/commit/af723fc14c8afa3a5b5a9ebbf7b78948a907ef27#diff-3b7a681602096a9164ff064b9d2777ce4eaf2c5848198ab1effea9c22f67bad6) on October 21 of 2020.
