### PR TITLE
Added check of exclusion files for keys relevance

### DIFF
--- a/.github/workflows/self-update.yml
+++ b/.github/workflows/self-update.yml
@@ -58,6 +58,20 @@ jobs:
 
                     echo ::set-output name=is_dirty::${IS_DIRTY}
 
+            -   name: Checking for excludes
+                if: success()
+                run: php app/excludes.php
+
+            -   name: Commit files after checking for excludes
+                id: excludes
+                if: success()
+                run: |
+                    IS_DIRTY=1
+
+                    { git add . && git commit -a -m "Updating excludes files"; } || IS_DIRTY=0
+
+                    echo ::set-output name=is_dirty::${IS_DIRTY}
+
             -   name: Status update
                 if: success()
                 run: php app/status.php
@@ -74,6 +88,6 @@ jobs:
 
             -   name: Push changes
                 uses: ad-m/github-push-action@master
-                if: success() && (steps.commit_keys.outputs.is_dirty == 1 || steps.referents.outputs.is_dirty == 1 || steps.commit_status.outputs.is_dirty == 1)
+                if: success() && (steps.commit_keys.outputs.is_dirty == 1 || steps.referents.outputs.is_dirty == 1 || steps.excludes.outputs.is_dirty == 1 || steps.commit_status.outputs.is_dirty == 1)
                 with:
                     github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/app/excludes.php
+++ b/app/excludes.php
@@ -1,0 +1,11 @@
+<?php
+
+use LaravelLang\Lang\Processors\Excludes;
+use LaravelLang\Lang\Services\Filesystem\Php;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+/** @var \LaravelLang\Lang\Application $app */
+$app = require_once __DIR__ . '/bootstrap/app.php';
+
+$app->processor(Excludes::make(), Php::make());

--- a/app/main/Concerns/Contains.php
+++ b/app/main/Concerns/Contains.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LaravelLang\Lang\Concerns;
+
+use Helldar\Support\Facades\Helpers\Str;
+
+trait Contains
+{
+    protected function isJson(string $filename): bool
+    {
+        return Str::endsWith($filename, '.json');
+    }
+
+    protected function isValidation(string $filename): bool
+    {
+        return Str::startsWith($filename, 'validation');
+    }
+}

--- a/app/main/Concerns/Storable.php
+++ b/app/main/Concerns/Storable.php
@@ -3,10 +3,13 @@
 namespace LaravelLang\Lang\Concerns;
 
 use Helldar\Support\Facades\Helpers\Instance;
+use Helldar\Support\Tools\Stub;
 use LaravelLang\Lang\Contracts\Stringable;
 
 trait Storable
 {
+    protected ?string $stub = null;
+
     protected function prepareToStore(array|string|Stringable $content): string
     {
         if (Instance::of($content, Stringable::class)) {
@@ -18,5 +21,19 @@ trait Storable
         }
 
         return $content;
+    }
+
+    protected function getStub(string $filename): string
+    {
+        return $this->findStub($this->stub ?: $filename);
+    }
+
+    protected function findStub(string $filename): string
+    {
+        $basename = pathinfo($filename, PATHINFO_FILENAME);
+
+        $path = $this->app->resourcePath('arrays/' . $basename . '.stub');
+
+        return file_exists($path) ? $path : Stub::PHP_ARRAY;
     }
 }

--- a/app/main/Contracts/Filesystem.php
+++ b/app/main/Contracts/Filesystem.php
@@ -2,6 +2,7 @@
 
 namespace LaravelLang\Lang\Contracts;
 
+use Helldar\Support\Tools\Stub;
 use LaravelLang\Lang\Application;
 
 interface Filesystem
@@ -10,5 +11,5 @@ interface Filesystem
 
     public function load(string $path): array;
 
-    public function store(string $path, array|string|Stringable $content): void;
+    public function store(string $path, array|string|Stringable $content, bool $is_simple = false, string $stub = Stub::PHP_ARRAY): void;
 }

--- a/app/main/Processors/Excludes.php
+++ b/app/main/Processors/Excludes.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace LaravelLang\Lang\Processors;
+
+use Helldar\Support\Facades\Helpers\Arr;
+use Helldar\Support\Facades\Helpers\Filesystem\File;
+
+class Excludes extends Processor
+{
+    protected string $target_path = 'excludes';
+
+    protected array $keys = [];
+
+    protected ?string $stub = 'exclude.stub';
+
+    public function run(): void
+    {
+        $this->loadKeys();
+        $this->handle();
+    }
+
+    protected function handle(): void
+    {
+        foreach ($this->targetFiles() as $filename) {
+            $this->process($this->getTargetPath($filename), $filename);
+        }
+    }
+
+    protected function process(string $target_path, string $filename, string $locale = null): void
+    {
+        $target = $this->load($target_path);
+
+        $content = $this->merge($this->keys, $target, $filename);
+
+        $this->sort($content);
+
+        $this->store($target_path, array_values($content), $this->stub, true);
+    }
+
+    protected function merge(array $source, array $target, string $filename): array
+    {
+        return array_intersect($source, $target);
+    }
+
+    protected function sort(array &$array): void
+    {
+        $array = Arr::sort(array_unique($array));
+    }
+
+    protected function loadKeys(): void
+    {
+        foreach ($this->sourceFiles() as $filename) {
+            $keys = $this->getSourceKeys($filename);
+
+            $this->keys = array_merge($this->keys, $keys);
+        }
+    }
+
+    protected function sourceFiles(): array
+    {
+        return File::names($this->getSourcePath());
+    }
+
+    protected function targetFiles(): array
+    {
+        return File::names($this->getTargetPath());
+    }
+
+    protected function getSourceKeys(string $filename): array
+    {
+        $items = $this->load($this->getSourcePath($filename));
+
+        return array_keys($items);
+    }
+}

--- a/app/main/Processors/Statuses/Processor.php
+++ b/app/main/Processors/Statuses/Processor.php
@@ -9,11 +9,7 @@ use Helldar\Support\Facades\Helpers\Str;
 use Helldar\Support\Facades\Tools\Sorter;
 use LaravelLang\Lang\Concerns\Excludes;
 use LaravelLang\Lang\Concerns\Template;
-use LaravelLang\Lang\Contracts\Filesystem;
 use LaravelLang\Lang\Processors\Processor as BaseProcessor;
-use LaravelLang\Lang\Services\Filesystem\Base;
-use LaravelLang\Lang\Services\Filesystem\Json as JsonFilesystem;
-use LaravelLang\Lang\Services\Filesystem\Php as PhpFilesystem;
 
 abstract class Processor extends BaseProcessor
 {
@@ -23,9 +19,6 @@ abstract class Processor extends BaseProcessor
     protected string $extension = '.md';
 
     protected string $target_path = 'statuses';
-
-    /** @var \LaravelLang\Lang\Contracts\Filesystem[]|array */
-    protected array $filesystems = [];
 
     protected array $source_files = [];
 
@@ -51,7 +44,7 @@ abstract class Processor extends BaseProcessor
         }
     }
 
-    protected function process(string $target_path, string $filename, string $locale): void
+    protected function process(string $target_path, string $filename, string $locale = null): void
     {
         $corrected = $this->getCorrectedFilename($filename, $locale);
 
@@ -95,32 +88,6 @@ abstract class Processor extends BaseProcessor
         $items = array_map(static fn (array $items) => count($items), $this->locales[$locale]);
 
         return array_sum($items);
-    }
-
-    protected function load(string $path): array
-    {
-        return $this->getFilesystem($path)->load($path);
-    }
-
-    protected function loadFilesystem(Filesystem|Base|string $filesystem): Filesystem
-    {
-        return $filesystem::make()->application($this->app);
-    }
-
-    protected function getFilesystem(string $filename): Filesystem
-    {
-        $class = $this->getFilesystemClass($filename);
-
-        if ($this->filesystems[$class] ?? false) {
-            return $this->filesystems[$class];
-        }
-
-        return $this->filesystems[$class] = $this->loadFilesystem($class);
-    }
-
-    protected function getFilesystemClass(string $path): string
-    {
-        return $this->isJson($path) ? JsonFilesystem::class : PhpFilesystem::class;
     }
 
     protected function getLangPath(string $locale = null): string
@@ -177,11 +144,6 @@ abstract class Processor extends BaseProcessor
             : $this->app->path('src/' . $locale . '/' . $filename);
 
         return $this->load($path);
-    }
-
-    protected function isJson(string $filename): bool
-    {
-        return Str::endsWith($filename, '.json');
     }
 
     protected function ensureDirectory(): void

--- a/app/main/Services/Filesystem/Base.php
+++ b/app/main/Services/Filesystem/Base.php
@@ -3,6 +3,7 @@
 namespace LaravelLang\Lang\Services\Filesystem;
 
 use Helldar\Support\Concerns\Makeable;
+use Helldar\Support\Facades\Helpers\Arr;
 use LaravelLang\Lang\Application;
 use LaravelLang\Lang\Concerns\Storable;
 use LaravelLang\Lang\Contracts\Filesystem;
@@ -24,5 +25,10 @@ abstract class Base implements Filesystem
     public function load(string $path): array
     {
         return [];
+    }
+
+    protected function correctValues(array $items): array
+    {
+        return Arr::map($items, static fn ($value) => str_replace('\"', '"', $value), true);
     }
 }

--- a/app/main/Services/Filesystem/Json.php
+++ b/app/main/Services/Filesystem/Json.php
@@ -4,6 +4,7 @@ namespace LaravelLang\Lang\Services\Filesystem;
 
 use Helldar\PrettyArray\Services\File as Pretty;
 use Helldar\Support\Facades\Helpers\Arr;
+use Helldar\Support\Tools\Stub;
 use LaravelLang\Lang\Contracts\Stringable;
 
 final class Json extends Base
@@ -12,11 +13,17 @@ final class Json extends Base
     {
         $content = Pretty::make()->loadRaw($path);
 
-        return json_decode($content, true);
+        $items = json_decode($content, true);
+
+        return $this->correctValues($items);
     }
 
-    public function store(string $path, array|string|Stringable $content): void
+    public function store(string $path, array|string|Stringable $content, bool $is_simple = false, string $stub = Stub::PHP_ARRAY): void
     {
+        if ($is_simple) {
+            $content = array_values($content);
+        }
+
         Arr::storeAsJson($path, $content, false, JSON_UNESCAPED_UNICODE ^ JSON_PRETTY_PRINT);
     }
 }

--- a/app/main/Services/Filesystem/Markdown.php
+++ b/app/main/Services/Filesystem/Markdown.php
@@ -3,11 +3,12 @@
 namespace LaravelLang\Lang\Services\Filesystem;
 
 use Helldar\Support\Facades\Helpers\Filesystem\File;
+use Helldar\Support\Tools\Stub;
 use LaravelLang\Lang\Contracts\Stringable;
 
 final class Markdown extends Base
 {
-    public function store(string $path, array|string|Stringable $content): void
+    public function store(string $path, array|string|Stringable $content, bool $is_simple = false, string $stub = Stub::PHP_ARRAY): void
     {
         $content = $this->prepareToStore($content);
 

--- a/app/main/Services/Filesystem/Php.php
+++ b/app/main/Services/Filesystem/Php.php
@@ -4,20 +4,26 @@ namespace LaravelLang\Lang\Services\Filesystem;
 
 use Helldar\PrettyArray\Services\File as Pretty;
 use Helldar\PrettyArray\Services\Formatter;
+use Helldar\Support\Tools\Stub;
 use LaravelLang\Lang\Contracts\Stringable;
 
 final class Php extends Base
 {
     public function load(string $path): array
     {
-        return Pretty::make()->load($path);
+        $items = Pretty::make()->load($path);
+
+        return $this->correctValues($items);
     }
 
-    public function store(string $path, array|string|Stringable $content): void
+    public function store(string $path, array|string|Stringable $content, bool $is_simple = false, string $stub = Stub::PHP_ARRAY): void
     {
         $service = Formatter::make();
-        $service->setEqualsAlign();
 
-        Pretty::make($service->raw($content))->store($path);
+        $is_simple
+            ? $service->setSimple()
+            : $service->setEqualsAlign();
+
+        Pretty::make($service->raw($content))->store($path, $this->getStub($stub));
     }
 }

--- a/app/resources/arrays/auth.stub
+++ b/app/resources/arrays/auth.stub
@@ -1,0 +1,14 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Authentication Language Lines
+|--------------------------------------------------------------------------
+|
+| The following language lines are used during authentication for various
+| messages that we need to display to the user. You are free to modify
+| these language lines according to your application's requirements.
+|
+*/
+
+return {{slot}};

--- a/app/resources/arrays/exclude.stub
+++ b/app/resources/arrays/exclude.stub
@@ -1,0 +1,13 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Exclusion list
+|--------------------------------------------------------------------------
+|
+| This is a list of exclusions for words or phrases where the original
+| form of the word has the same spelling in a given language.
+|
+*/
+
+return {{slot}};

--- a/app/resources/arrays/pagination.stub
+++ b/app/resources/arrays/pagination.stub
@@ -1,0 +1,14 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Pagination Language Lines
+|--------------------------------------------------------------------------
+|
+| The following language lines are used by the paginator library to build
+| the simple pagination links. You are free to change them to anything
+| you want to customize your views to better match your application.
+|
+*/
+
+return {{slot}};

--- a/app/resources/arrays/passwords.stub
+++ b/app/resources/arrays/passwords.stub
@@ -1,0 +1,14 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Password Reset Language Lines
+|--------------------------------------------------------------------------
+|
+| The following language lines are the default lines which match reasons
+| that are given by the password broker for a password update attempt
+| has failed, such as for an invalid token or invalid new password.
+|
+*/
+
+return {{slot}};

--- a/app/resources/arrays/validation-inline.stub
+++ b/app/resources/arrays/validation-inline.stub
@@ -1,0 +1,14 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Validation Language Lines
+|--------------------------------------------------------------------------
+|
+| The following language lines contain the default error messages used by
+| the validator class. Some of these rules have multiple versions such
+| as the size rules. Feel free to tweak each of these messages here.
+|
+*/
+
+return {{slot}};

--- a/app/resources/arrays/validation.stub
+++ b/app/resources/arrays/validation.stub
@@ -1,0 +1,14 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Validation Language Lines
+|--------------------------------------------------------------------------
+|
+| The following language lines contain the default error messages used by
+| the validator class. Some of these rules have multiple versions such
+| as the size rules. Feel free to tweak each of these messages here.
+|
+*/
+
+return {{slot}};

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     },
     "require-dev": {
         "php": "^8.0",
-        "andrey-helldar/pretty-array": "^2.1",
-        "andrey-helldar/support": "^3.2",
+        "andrey-helldar/pretty-array": "^2.3",
+        "andrey-helldar/support": "^3.4",
         "phpunit/phpunit": "^9.5",
         "symfony/var-dumper": "^5.2"
     },


### PR DESCRIPTION
* Added check of exclusion files for keys relevance
* Added templates for saving files

Before > After:

> Excludes file
>
> ![image](https://user-images.githubusercontent.com/10347617/114277104-7eb89380-9a32-11eb-8e23-e70463c33447.png)

> Locale's file
>
> ![image](https://user-images.githubusercontent.com/10347617/114277140-a7408d80-9a32-11eb-935b-688753b13f52.png)

What problems have been solved:

1. Duplicate keys were specified in some exclusion files;
2. There was no sorting in the exclusion files;
3. Some keys were excluded from the main files.

What's happening:
1. Values are sorted alphabetically;
2. Keys deleted from EN files are excluded (both php and json files are checked);
3. A comment is inserted at the beginning of each file.

Also, when processing translation files, a comment is now inserted with the description of this file (`app/resources/arrays/*.stub`).

The commentary is indicated in English only and is for information only. It is NOT NECESSARY to change the comment text directly in the file - it will be automatically replaced with the default one.
