### PR TITLE
Added check for ":Attribute" when running tests

### DIFF
--- a/app/tests/PhpTest.php
+++ b/app/tests/PhpTest.php
@@ -21,7 +21,7 @@ final class PhpTest extends TestCase
                 $this->assertSame(array_keys($source), array_keys($target), $this->messageForLocale($path, $locale));
 
                 if ($this->isInline($filename)) {
-                    $this->assertDoesntSee($path, ':attribute');
+                    $this->assertDoesntSee($path, [':attribute', ':Attribute']);
                 }
             }
         }

--- a/app/tests/TestCase.php
+++ b/app/tests/TestCase.php
@@ -43,14 +43,18 @@ abstract class TestCase extends BaseTestCase
         );
     }
 
-    protected function assertDoesntSee(string $path, string $content): void
+    protected function assertDoesntSee(string $path, string|array $content): void
     {
         $file = File::make()->loadRaw($path);
 
-        $this->assertFalse(
-            str_contains($file, $content),
-            $this->messageAssertDoesntSee($path, $content)
-        );
+        $values = Arr::wrap($content);
+
+        foreach ($values as $value) {
+            $this->assertFalse(
+                str_contains($file, $value),
+                $this->messageAssertDoesntSee($path, $value)
+            );
+        }
     }
 
     protected function sort(array &$array): void


### PR DESCRIPTION
I've noticed that some people use `:Attribute` rather than `:attribute` at the beginning of a sentence (for example: [here](https://github.com/Laravel-Lang/lang/pull/1615/files#diff-0ecf1116fcf054e48b4f8a53c508f460bb59310aac195515c515f4f6613661fbL90-L104), [here](https://github.com/Laravel-Lang/lang/pull/1616/files#diff-0ecf1116fcf054e48b4f8a53c508f460bb59310aac195515c515f4f6613661fbL20-L106)). Since the tests are case sensitive, they do not consider `:Attribute` an error. Therefore, I added such a variant of the word spelling when checking the `validation-inline.php` file.

**Before:**

![image](https://user-images.githubusercontent.com/10347617/114828579-c0e72980-9dd2-11eb-9682-c26a83f4318f.png)

**After:**

![image](https://user-images.githubusercontent.com/10347617/114828608-cba1be80-9dd2-11eb-831d-00c9f86da9af.png)
