### PR TITLE
Removed special characters from the commit header

### DIFF
--- a/.github/workflows/self-update.yml
+++ b/.github/workflows/self-update.yml
@@ -62,7 +62,7 @@ jobs:
 
                     php app/referents.php
 
-                    { git add . && git commit -a -m "Updating the `docs/referents.md` file"; } || IS_DIRTY=0
+                    { git add . && git commit -a -m "Updating the docs/referents.md file"; } || IS_DIRTY=0
 
                     echo ::set-output name=is_dirty::${IS_DIRTY}
 


### PR DESCRIPTION
For some reason unknown to me, GitHub Actions strips the special characters from the commit header, forming a header like `Updating the file`.