### PR TITLE
[en, es] Add validation.current_password rule

### DIFF
--- a/locales/es/validation-inline.php
+++ b/locales/es/validation-inline.php
@@ -31,6 +31,7 @@ return [
     ],
     'boolean'              => 'El campo debe ser verdadero o falso.',
     'confirmed'            => 'La confirmación no coincide.',
+    'current_password'     => 'La contraseña es incorrecta.',
     'date'                 => 'Esta no es una fecha válida.',
     'date_equals'          => 'El campo debe ser una fecha igual a :date.',
     'date_format'          => 'El campo no corresponde al formato :format.',

--- a/locales/es/validation.php
+++ b/locales/es/validation.php
@@ -31,6 +31,7 @@ return [
     ],
     'boolean'              => 'El campo :attribute debe tener un valor verdadero o falso.',
     'confirmed'            => 'La confirmación de :attribute no coincide.',
+    'current_password'     => 'La contraseña es incorrecta.',
     'date'                 => ':attribute no es una fecha válida.',
     'date_equals'          => ':attribute debe ser una fecha igual a :date.',
     'date_format'          => ':attribute no corresponde al formato :format.',

--- a/source/validation-inline.php
+++ b/source/validation-inline.php
@@ -32,6 +32,7 @@ return [
     ],
     'boolean'              => 'This field must be true or false.',
     'confirmed'            => 'The confirmation does not match.',
+    'current_password'     => 'The password is incorrect.',
     'date'                 => 'This is not a valid date.',
     'date_equals'          => 'This must be a date equal to :date.',
     'date_format'          => 'This does not match the format :format.',

--- a/source/validation.php
+++ b/source/validation.php
@@ -31,6 +31,7 @@ return [
     ],
     'boolean'              => 'The :attribute field must be true or false.',
     'confirmed'            => 'The :attribute confirmation does not match.',
+    'current_password'     => 'The password is incorrect.',
     'date'                 => 'The :attribute is not a valid date.',
     'date_equals'          => 'The :attribute must be a date equal to :date.',
     'date_format'          => 'The :attribute does not match the format :format.',


### PR DESCRIPTION
[This rule](https://github.com/laravel/laravel/blob/8.x/resources/lang/en/validation.php#L34) will replace the rule `password` in the next major version of Laravel.

- [https://github.com/laravel/laravel/pull/5628](https://github.com/laravel/laravel/pull/5628)