### PR TITLE
[IT] Added italian translation for Owner role of Jetstream

### DIFF
--- a/locales/it/it.json
+++ b/locales/it/it.json
@@ -400,6 +400,7 @@
     "Only Trashed": "Solo cestinati",
     "Original": "Originale",
     "Our billing management portal allows you to conveniently manage your subscription plan, payment method, and download your recent invoices.": "Il nostro portale di fatturazione ti consente di gestire l'abbonamento, il metodo di pagamento, e scaricare le fatture recenti.",
+    "Owner": "Proprietario",
     "Page Expired": "Pagina scaduta",
     "Pagination Navigation": "Navigazione della Paginazione",
     "Pakistan": "Pakistan",

--- a/source/packages/jetstream.json
+++ b/source/packages/jetstream.json
@@ -71,6 +71,7 @@
     "New Password",
     "Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information regarding this team that you wish to retain.",
     "Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.",
+    "Owner",
     "Password",
     "Pending Team Invitations",
     "Permanently delete this team.",


### PR DESCRIPTION
I've seen that there's no translation for Owner role in Jetstream.