### PR TITLE
Removing the `attached` and `relatable` keys

### DIFF
--- a/source/validation-inline.php
+++ b/source/validation-inline.php
@@ -22,7 +22,6 @@ return [
     'alpha_dash'           => 'This field may only contain letters, numbers, dashes and underscores.',
     'alpha_num'            => 'This field may only contain letters and numbers.',
     'array'                => 'This field must be an array.',
-    'attached'             => 'This field is already attached.',
     'before'               => 'This must be a date before :date.',
     'before_or_equal'      => 'This must be a date before or equal to :date.',
     'between'              => [
@@ -102,7 +101,6 @@ return [
     'password'             => 'The password is incorrect.',
     'present'              => 'This field must be present.',
     'regex'                => 'This format is invalid.',
-    'relatable'            => 'This field may not be associated with this resource.',
     'required'             => 'This field is required.',
     'required_if'          => 'This field is required when :other is :value.',
     'required_unless'      => 'This field is required unless :other is in :values.',

--- a/source/validation.php
+++ b/source/validation.php
@@ -21,7 +21,6 @@ return [
     'alpha_dash'           => 'The :attribute may only contain letters, numbers, dashes and underscores.',
     'alpha_num'            => 'The :attribute may only contain letters and numbers.',
     'array'                => 'The :attribute must be an array.',
-    'attached'             => 'This :attribute is already attached.',
     'before'               => 'The :attribute must be a date before :date.',
     'before_or_equal'      => 'The :attribute must be a date before or equal to :date.',
     'between'              => [
@@ -101,7 +100,6 @@ return [
     'password'             => 'The password is incorrect.',
     'present'              => 'The :attribute field must be present.',
     'regex'                => 'The :attribute format is invalid.',
-    'relatable'            => 'This :attribute may not be associated with this resource.',
     'required'             => 'The :attribute field is required.',
     'required_if'          => 'The :attribute field is required when :other is :value.',
     'required_unless'      => 'The :attribute field is required unless :other is in :values.',


### PR DESCRIPTION
See:
- https://github.com/laravel/laravel/blob/8.x/resources/lang/en/validation.php
- https://github.com/laravel/laravel/blob/7.x/resources/lang/en/validation.php

PS: Tests fail because the composition of the keys has been changed