### PR TITLE
Fixed Class "LaravelLang\Publisher\Concerns\BaseServiceProvider" not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,12 +59,5 @@
         "sort-packages": true
     },
     "minimum-stability": "stable",
-    "prefer-stable": true,
-    "extra": {
-        "laravel": {
-            "providers": [
-                "LaravelLang\\Lang\\ServiceProvider"
-            ]
-        }
-    }
+    "prefer-stable": true
 }


### PR DESCRIPTION
The tests return an error because https://github.com/Laravel-Lang/lang/pull/1943 no has been accepted. He corrects this error.