### PR TITLE
[tr] Add missing translations

### DIFF
--- a/locales/tr/tr.json
+++ b/locales/tr/tr.json
@@ -610,7 +610,7 @@
     "These people have been invited to your team and have been sent an invitation email. They may join the team by accepting the email invitation.": "Bu kişiler ekibinize davet edildi ve bir davet e-postası gönderildi. E-posta davetiyesini kabul ederek ekibe katılabilirler.",
     "This account does not have an active subscription.": "Bu hesabın aktif bir aboneliği yok.",
     "This action is unauthorized.": "Bu işleme izin verilmiyor.",
-    "This coupon code can only be used by new customers.": "This coupon code can only be used by new customers.",
+    "This coupon code can only be used by new customers.": "Bu kupon kodu sadece yeni müşteriler tarafından kullanılabilir.",
     "This device": "Bu cihaz",
     "This file field is read-only.": "Bu dosya alanı salt okunur.",
     "This image": "Bu görüntü",


### PR DESCRIPTION
This PR adds the missing translations in [`tr.json`](https://github.com/Laravel-Lang/lang/blob/main/locales/tr/tr.json#L613):
 - "This coupon code can only be used by new customers."