### PR TITLE
[ja] delete [:displayableActionUrl](:actionURL) 

### DIFF
--- a/locales/ja/ja.json
+++ b/locales/ja/ja.json
@@ -276,7 +276,7 @@
     "If you did not request a password reset, no further action is required.": "パスワード再設定のリクエストにお心当たりがない場合は、このメールを無視してください。",
     "If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the team invitation:": "アカウントをお持ちでない場合は、以下のボタンをクリックしてアカウントを作成できます。アカウント作成後は招待メールのリンクをクリックして登録を完了してください。",
     "If you need to add specific contact or tax information to your receipts, like your full business name, VAT identification number, or address of record, you may add it here.": "領収書に社名や住所など追加の情報を記載する場合はこちらに記入してください。",
-    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "\":actionText\"ボタンがクリックできない場合は以下のURLを直接入力してください。",
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "\":actionText\"ボタンがクリックできない場合は以下のURLを直接入力してください。[:displayableActionUrl](:actionURL)",
     "Increase": "増やす",
     "India": "インド",

--- a/locales/ja/ja.json
+++ b/locales/ja/ja.json
@@ -277,7 +277,7 @@
     "If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the team invitation:": "アカウントをお持ちでない場合は、以下のボタンをクリックしてアカウントを作成できます。アカウント作成後は招待メールのリンクをクリックして登録を完了してください。",
     "If you need to add specific contact or tax information to your receipts, like your full business name, VAT identification number, or address of record, you may add it here.": "領収書に社名や住所など追加の情報を記載する場合はこちらに記入してください。",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "\":actionText\"ボタンがクリックできない場合は以下のURLを直接入力してください。",
-    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "\":actionText\"ボタンがクリックできない場合は以下のURLを直接入力してください。[:displayableActionUrl](:actionURL)",
+    "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "\":actionText\"ボタンがクリックできない場合は以下のURLを直接入力してください。",
     "Increase": "増やす",
     "India": "インド",
     "Indonesia": "インドネシア",


### PR DESCRIPTION
- related issue: [problem with lang.json](https://github.com/Laravel-Lang/lang/issues/1226)
- related commit: [feature: delete \[:displayableActionUrl\](:actionURL)](https://github.com/Laravel-Lang/lang/commit/72cec64bc9524af2f3cc390590c6b95f1de05057)
- I think he accidentally forgot to erase one of the two \[:displayableActionUrl\](:actionURL) in ja.json