### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,6 +2,9 @@ name: phpunit
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,8 +2,7 @@ name: phpunit
 
 on: [ push, pull_request ]
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
     build:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
