### PR TITLE
Correct the Cameroon country name in portuguese

### DIFF
--- a/locales/pt/pt.json
+++ b/locales/pt/pt.json
@@ -111,7 +111,7 @@
     "Burkina Faso": "Burquina Faso",
     "Burundi": "Burundi",
     "Cambodia": "Camboja",
-    "Cameroon": "Camarao",
+    "Cameroon": "Camarões",
     "Canada": "Canadá",
     "Cancel": "Cancelar",
     "Cancel Subscription": "Cancelar Subscrição",


### PR DESCRIPTION
"Camarão" in english means shrimp, the correct name of Cameroon in portuguese is Camarões.