### PR TITLE
Correct the Cameroon country name in  portuguese

### DIFF
--- a/locales/pt_BR/pt_BR.json
+++ b/locales/pt_BR/pt_BR.json
@@ -111,7 +111,7 @@
     "Burkina Faso": "Burquina Faso",
     "Burundi": "Burundi",
     "Cambodia": "Camboja",
-    "Cameroon": "Camarão",
+    "Cameroon": "Camarões",
     "Canada": "Canadá",
     "Cancel": "Cancelar",
     "Cancel Subscription": "Cancelar a assinatura",


### PR DESCRIPTION
"Camarão" in english means shrimp, the correct name of Cameroon in portuguese is Camarões.
even in Brazilian portuguese