### PR TITLE
[ro]: Fix translation

### DIFF
--- a/locales/ro/json.json
+++ b/locales/ro/json.json
@@ -41,7 +41,7 @@
     "An error occured while uploading the file.": "A apărut o eroare la încărcarea fișierului.",
     "An error occurred while uploading the file.": "An error occurred while uploading the file.",
     "An unexpected error occurred and we have notified our support team. Please try again later.": "An unexpected error occurred and we have notified our support team. Please try again later.",
-    "Andorra": "Andorrană",
+    "Andorra": "Andorra",
     "Angola": "Angola",
     "Anguilla": "Anguilla",
     "Another user has updated this resource since this page was loaded. Please refresh the page and try again.": "Un alt utilizator a actualizat această resursă de când a fost încărcată această pagină. Reîmprospătați pagina și încercați din nou.",


### PR DESCRIPTION
In romanian **Andorra** is `Andorra`  