### PR TITLE
[nl]: Remove misplaced space in 'datalek'

### DIFF
--- a/locales/nl/php.json
+++ b/locales/nl/php.json
@@ -82,7 +82,7 @@
     "password.mixed": ":Attribute moet minimaal één kleine letter en één hoofdletter bevatten.",
     "password.numbers": ":Attribute moet minimaal één cijfer bevatten.",
     "password.symbols": ":Attribute moet minimaal één vreemd teken bevatten.",
-    "password.uncompromised": "Het opgegeven :attribute komt voor in een data lek. Kies een ander :attribute.",
+    "password.uncompromised": "Het opgegeven :attribute komt voor in een datalek. Kies een ander :attribute.",
     "present": ":Attribute moet aanwezig zijn.",
     "previous": "&laquo; Vorige",
     "prohibited": ":Attribute is niet toegestaan.",


### PR DESCRIPTION
Should be a single word.