### PR TITLE
[th]: Update json.json: "Thailand": "ประเทศไทย" -> "ไทย"

### DIFF
--- a/locales/th/json.json
+++ b/locales/th/json.json
@@ -628,7 +628,7 @@
     "Subscription Information": "ข้อมูลการสมัครสมาชิก",
     "Subscription Pending": "การสมัครสมาชิก รอดำเนินการ",
     "Sudan": "ซูดาน",
-    "Suriname": "ซูรินาเม",
+    "Suriname": "ซูรินาม",
     "Svalbard And Jan Mayen": "สฟาลบาร์และยานไมเอน",
     "Svalbard and Jan Mayen": "สฟาลบาร์และยานไมเอน",
     "Swaziland": "เอสวาตินี",

--- a/locales/th/json.json
+++ b/locales/th/json.json
@@ -650,7 +650,7 @@
     "Team Owner": "เจ้าของทีม",
     "Team Settings": "ทีมการตั้งค่า",
     "Terms of Service": "เงื่อนไขของบริการ",
-    "Thailand": "ประเทศไทย",
+    "Thailand": "ไทย",
     "Thanks for signing up! Before getting started, could you verify your email address by clicking on the link we just emailed to you? If you didn't receive the email, we will gladly send you another.": "ขอบคุณสำหรับการสมัคร! ก่อนเริ่มต้น คุณสามารถยืนยันที่อยู่อีเมลของคุณโดยคลิกลิงก์ที่เราเพิ่งส่งอีเมลถึงคุณได้หรือไม่ หากคุณไม่ได้รับอีเมล เรายินดีที่จะส่งใหม่ให้คุณ",
     "Thanks for your continued support. We've attached a copy of your invoice for your records. Please let us know if you have any questions or concerns.": "ขอบคุณสำหรับการสนับสนุนอย่างต่อเนื่องของคุณ เราได้แนบสำเนาใบแจ้งหนี้ของคุณเพื่อบันทึก โปรดแจ้งให้เราทราบหากคุณมีคำถามหรือข้อกังวลใดๆ",
     "Thanks,": "ขอบคุณ,",


### PR DESCRIPTION
Change "Thailand" translation from "ประเทศไทย" to "ไทย".

Based on the translation of other country names, like:

```json
    "Tajikistan": "ทาจีกิสถาน",
    "Tanzania": "แทนซาเนีย",
    "Tanzania, United Republic of": "แทนซาเนีย, สหสาธารณรัฐ",
```

They don't include the prefix "ประเทศ" ("country") in their translation.

So the translation of "Thailand" should not include "ประเทศ" as well.

This will make it consistent for the user and make it easier to find country names when sorted alphabetically (with a locale-aware collator).