### PR TITLE
[source]: Add missing extended translation to framework.

### DIFF
--- a/source/framework/extended.json
+++ b/source/framework/extended.json
@@ -2,5 +2,6 @@
     "(and :count more error)": "(and :count more error)",
     "(and :count more errors)": "(and :count more errors)",
     "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:",
-    "The given data was invalid.": "The given data was invalid."
+    "The given data was invalid.": "The given data was invalid.",
+    "This action is unauthorized.": "This action is unauthorized."
 }


### PR DESCRIPTION
In one of my projects I found that the string `'This action is unauthorized.'` is not translated but it has translation support within the framework. To obtain its translation, just add it to the `.json` and translate it.

![image](https://github.com/Laravel-Lang/lang/assets/9275870/817697b1-15d7-46be-a72b-3aea804f12c4)

This message is visible in the error template when an authorization exception is thrown.

Support for translation is not direct. Let's see where it is ...

if you throw an `Illuminate\Auth\Access\AuthorizationException` the template `.../Illuminate/Foundation/Exceptions/views/403.blade.php` is rendered.

```php
@extends('errors::minimal')

@section('title', __('Forbidden'))
@section('code', '403')
@section('message', __($exception->getMessage() ?: 'Forbidden'))
```
in the [Line 5](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Exceptions/views/403.blade.php#L5) we can see the translation function.

In https://github.com/laravel/framework/blob/11.x/src/Illuminate/Auth/Access/AuthorizationException.php#L34 we see how this message is passed through the constructor method.
```php
    // ...
    public function __construct($message = null, $code = null, Throwable $previous = null)
    {
        parent::__construct($message ?? 'This action is unauthorized.', 0, $previous);

        $this->code = $code ?: 0;
    }

    // ...
```
