### PR TITLE
[nb]: Fix typo in Norwegian Bokmål

### DIFF
--- a/locales/nb/json.json
+++ b/locales/nb/json.json
@@ -523,7 +523,7 @@
     "Previous": "Tidligere",
     "Privacy Policy": "Personvernregler",
     "Profile": "Profil",
-    "Profile Information": "Profil informasjon",
+    "Profile Information": "Profilinformasjon",
     "Puerto Rico": "Puerto Rico",
     "Qatar": "Qatar",
     "Quarter To Date": "Kvartal til dags dato",


### PR DESCRIPTION
Fixing a typo: Changing 'Profil informasjon' to 'Profilinformasjon' to align with correct Norwegian spelling.