### PR TITLE
[bg]: Update incorrect translated word

### DIFF
--- a/locales/bg/json.json
+++ b/locales/bg/json.json
@@ -590,7 +590,7 @@
     "Sao Tome And Principe": "Сао Томе и Принсипи",
     "Sao Tome and Principe": "Сао Томе и Принсипи",
     "Saudi Arabia": "Саудитска Арабия",
-    "Save": "Запазя",
+    "Save": "Запази",
     "Saved.": "Запазено.",
     "Scroll to bottom": "Превъртете надолу",
     "Scroll to top": "Превъртете до върха",


### PR DESCRIPTION
The difference is in one word, but that makes a difference in important words such as "Save". 

Proof of correctness: https://translate.google.com/?sl=bg&tl=en&text=%D0%97%D0%B0%D0%BF%D0%B0%D0%B7%D0%B8&op=translate 

ps: Thanks for making and maintaining this package!