### PR TITLE
[ja]: Correcting of the meaning of the Japanese translation

### DIFF
--- a/locales/ja/json.json
+++ b/locales/ja/json.json
@@ -9,7 +9,7 @@
     ":days day trial": ":Days日のトライアル",
     ":resource Details": ":Resource詳細",
     ":resource Details: :title": ":Resource詳細 :title",
-    "A decryption key is required.": "複合キーは必須です。",
+    "A decryption key is required.": "復号キーは必須です。",
     "A fresh verification link has been sent to your email address.": "新しい確認リンクがメールアドレスに送信されました。",
     "A new verification link has been sent to the email address you provided during registration.": "入力いただいたメールアドレスに確認メールを送信しました。",
     "A new verification link has been sent to the email address you provided in your profile settings.": "登録いただいたメールアドレスに確認メールを送信しました。",

--- a/source/nova/5.x/nova.json
+++ b/source/nova/5.x/nova.json
@@ -9,6 +9,7 @@
     "A new verification link has been sent to the email address you provided in your profile settings.": "A new verification link has been sent to the email address you provided in your profile settings.",
     "This is a secure area of the application. Please confirm your password before continuing.": "This is a secure area of the application. Please confirm your password before continuing.",
     "Error": "Error",
+    "Current Password": "Current Password",
     "Confirm Password": "Confirm Password",
     "We have emailed your password reset link!": "We have emailed your password reset link!",
     "Dashboard": "Dashboard",


### PR DESCRIPTION
I hope this fix helps.

the difference of meaning "復号" and "複合"

- 複合 https://dictionary.goo.ne.jp/word/%E8%A4%87%E5%90%88/

- 復号 https://dictionary.goo.ne.jp/word/%E5%BE%A9%E5%8F%B7/ 