### PR TITLE
[ko]: Fix wrong translation value for contains key

### DIFF
--- a/locales/ko/json.json
+++ b/locales/ko/json.json
@@ -550,7 +550,7 @@
     "Remove": "제거",
     "Remove Photo": "사진 제거",
     "Remove Team Member": "팀 멤버 제거",
-    "Replicate": "뒤로 젖히다",
+    "Replicate": "복제하기",
     "Required fields": "필수 입력 사항",
     "Resend Verification Email": "확인 메일 다시 보내기",
     "Reset Filters": "필터 초기화",


### PR DESCRIPTION
I found the wrong translate value, so I have made PR.

File : /locales/ko/json.json

```diff
-    "Replicate": "뒤로 젖히다",
+    "Replicate": "복제하기",
```

Would you please merge it soon?

Thank you for helping me in advance.