### PR TITLE
[ko]: Translate the word `View` more correctly.

### DIFF
--- a/locales/ko/json.json
+++ b/locales/ko/json.json
@@ -801,7 +801,7 @@
     "Verify Email Address": "이메일 주소 확인",
     "Verify Your Email Address": "이메일 주소 확인",
     "Viet Nam": "베트남",
-    "View": "뷰",
+    "View": "보기",
     "Virgin Islands, British": "영국령 버진 아일랜드",
     "Virgin Islands, U.S.": "미국령 버진 아일랜드",
     "Wallis And Futuna": "월리스 푸 투나",


### PR DESCRIPTION
The English word "view" can function as both a verb and a noun, but in Korean, these meanings should be distinguished.

I suggest the following change:

```diff
- "View": "뷰",
+ "View": "보기",
```

In Korean, "뷰" is commonly used to refer to a sight, landscape, or scene, rather than the act of looking or seeing. To better reflect the intended meaning, "보기" would be a more appropriate translation.

<img width="429" alt="view_cannot_be_understood" src="https://github.com/user-attachments/assets/e7fe3077-b1cb-4071-9f52-325d7a0e3dae" />

I believe no Korean would understand the image above - "뷰".

Reference link - https://nova.laravel.com/docs/v4/resources/fields#tag-field