### PR TITLE
[ja]: Fix Typo in Japanese

### DIFF
--- a/locales/ja/json.json
+++ b/locales/ja/json.json
@@ -403,7 +403,7 @@
     "Malawi": "マラウイ",
     "Malaysia": "マレーシア",
     "Maldives": "モルディブ",
-    "Mali": "小さい",
+    "Mali": "マリ",
     "Malta": "マルタ",
     "Manage Account": "アカウント管理",
     "Manage and log out your active sessions on other browsers and devices.": "全ての端末からログアウトする。",


### PR DESCRIPTION
## what i done

``` before
"Mali": "小さい"
```
```after
"Mali": "マリ"
```

I made this change because, judging from the surrounding context, it seems that "Mali" is referring to the country rather than the adjective meaning "small" in Croatian or other Slavic languages.

However, if this key was intentionally translated to mean "small" in another language, please feel free to close this PR. I would appreciate your clarification in that case.

Thank you for your time and consideration.
