### PR TITLE
[bg]: Fix string parameter not being displayed

### DIFF
--- a/locales/bg/json.json
+++ b/locales/bg/json.json
@@ -332,7 +332,7 @@
     "If you did not request a password reset, no further action is required.": "Ако не сте поискали Нулиране на паролата, не са необходими допълнителни действия.",
     "If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the team invitation:": "Ако нямате профил, можете да го създадете, като кликнете върху бутона по-долу. След като създадете профил, можете да кликнете върху бутона за приемане на покана в този имейл, за да приемете поканата на екипа:",
     "If you need to add specific contact or tax information to your invoices, like your full business name, VAT identification number, or address of record, you may add it here.": "Ако трябва да добавите конкретна контактна или данъчна информация към вашите фактури, като вашето пълно име на фирм, идентификационен номер на ДДС или адрес на записа, можете да го добавите тук.",
-    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Ако имате проблеми с натискането на бутона \":actiontext\", копирайте и поставете URL адреса по-долу\nкъм вашия уеб браузър:",
+    "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "Ако имате проблеми с натискането на бутона \":actionText\", копирайте и поставете URL адреса по-долу\nкъм вашия уеб браузър:",
     "Impersonate": "Имитирайте се",
     "Increase": "Увеличаване",
     "India": "Индия",


### PR DESCRIPTION
The parameter in the translated string was actiontext instead of actionText.

<img width="535" height="90" alt="CleanShot 2025-08-07 at 09 44 25" src="https://github.com/user-attachments/assets/617870e2-9470-4434-8841-38be6d0547e5" />
