### PR TITLE
Fix Japanese translation "Swaziland" for "スイス" to "エスワティニ"

### DIFF
--- a/locales/ja/json.json
+++ b/locales/ja/json.json
@@ -652,7 +652,7 @@
     "Suriname": "スリナム",
     "Svalbard And Jan Mayen": "スヴァールバル諸島およびヤンマイエン島",
     "Svalbard and Jan Mayen": "スヴァールバル諸島およびヤンマイエン島",
-    "Swaziland": "スイス",
+    "Swaziland": "エスワティニ",
     "Sweden": "スウェーデン",
     "Switch Teams": "チーム切り替え",
     "Switzerland": "スイス",


### PR DESCRIPTION
### what i done

### Changes
- Updated `"Swaziland"` translation from `"スイス"` to `"エスワティニ"`.

### Rationale
Accurate country names are important for clarity and consistency in multilingual applications.  
This update ensures the translation:
- Matches the internationally recognised naming standard.
- Avoids confusion with Switzerland.
- Improves localisation quality for Japanese.