### PR TITLE
[es]: Fix Spanish translation for "Click to choose" (click → clic)

### DIFF
--- a/locales/es/json.json
+++ b/locales/es/json.json
@@ -159,7 +159,7 @@
     "City": "Ciudad",
     "Click here to re-send the verification email.": "Haga clic aquí para reenviar el correo de verificación.",
     "click here to request another": "haga clic aquí para solicitar otro",
-    "Click to choose": "Haga click para elegir",
+    "Click to choose": "Haga clic para elegir",
     "Close": "Cerrar",
     "Cocos (Keeling) Islands": "Islas Cocos (Keeling)",
     "Code": "Código",


### PR DESCRIPTION
## What I have done

### Changes
- Updated `"Click to choose"` translation from `"Haga click para elegir"` to `"Haga clic para elegir"`.

### Rationale
- **Linguistic correctness**: “clic” is the standard term in Spanish for a mouse click.
- **Consistency**: Aligns with other UI translations that follow RAE spelling.
- **Improved localisation quality**: Ensures correct and professional presentation in Spanish interfaces.