### PR TITLE
Fix Typo in Json file

### DIFF
--- a/locales/ja/json.json
+++ b/locales/ja/json.json
@@ -568,7 +568,7 @@
     "Resume Subscription": "サブスクリプションを再開",
     "Retry Payment": "支払いの再試行",
     "Return to :appName": ":appNameに戻る",
-    "Reunion": "打合せ",
+    "Reunion": "レユニオン",
     "Role": "役割",
     "Romania": "ルーマニア",
     "Run Action": "アクションを実行",


### PR DESCRIPTION
### what i have done

- [change Reunion translation into "レユニオン"](https://github.com/Laravel-Lang/lang/commit/82758d25990e8a40e53c53d4e3c1482e7b9d7d22)