### PR TITLE
[fa]: Added missing encoding validation translation

### DIFF
--- a/locales/fa/php-inline.json
+++ b/locales/fa/php-inline.json
@@ -36,7 +36,7 @@
     "doesnt_end_with": "این مقدار نباید با این مقادیر تمام شود : :values.",
     "doesnt_start_with": "این مقدار نباید با این مقادیر شروع شود : :values.",
     "email": "این مقدار باید یک آدرس ایمیل معتبر باشد.",
-    "encoding": "This field must be encoded in :encoding.",
+    "encoding": "این فیلد باید در :encoding رمزگذاری شود.",
     "ends_with": "این مقدار باید با یکی از عبارت های روبرو پایان یابد: :values.",
     "enum": "مقدار انتخابی معتبر نیست.",
     "exists": "مقدار انتخابی وجود ندارد.",

--- a/locales/fa/php.json
+++ b/locales/fa/php.json
@@ -37,7 +37,7 @@
     "doesnt_end_with": "مقدار :attribute نباید با این مقادیر تمام شود : :values.",
     "doesnt_start_with": "مقدار :attribute نباید با این مقادیر شروع شود : :values.",
     "email": ":Attribute باید یک ایمیل معتبر باشد.",
-    "encoding": "The :attribute field must be encoded in :encoding.",
+    "encoding": "فیلد :attribute باید در :encoding رمزگذاری شود.",
     "ends_with": "فیلد :attribute باید با یکی از مقادیر زیر خاتمه یابد: :values",
     "enum": ":Attribute انتخاب شده اشتباه است.",
     "exists": ":Attribute انتخاب شده، معتبر نیست.",


### PR DESCRIPTION
This PR adds the missing `encoding` validation message to Persian (fa) locale:
- php.json
- php-inline.json