### PR TITLE
[ja]: Add missing Japanese translation for encoding rule

### DIFF
--- a/locales/ja/php-inline.json
+++ b/locales/ja/php-inline.json
@@ -36,7 +36,7 @@
     "doesnt_end_with": "「:values」以外で終わる必要があります。",
     "doesnt_start_with": "「:values」以外で始まる必要があります。",
     "email": "無効なメールアドレスです。",
-    "encoding": "This field must be encoded in :encoding.",
+    "encoding": ":encodingでエンコードされている必要があります。",
     "ends_with": "次のいずれかで終わる必要があります: :values",
     "enum": "選択された値は無効です。",
     "exists": "選択した値が無効です。",

--- a/locales/ja/php.json
+++ b/locales/ja/php.json
@@ -37,7 +37,7 @@
     "doesnt_end_with": ":attributeの終わりは「:values」以外である必要があります。",
     "doesnt_start_with": ":attributeの始まりは「:values」以外である必要があります。",
     "email": ":attributeは、有効なメールアドレス形式で指定してください。",
-    "encoding": "The :attribute field must be encoded in :encoding.",
+    "encoding": ":attributeは、:encodingでエンコードされている必要があります。",
     "ends_with": ":attributeの終わりは「:values」である必要があります。",
     "enum": "選択した :attributeは 無効です。",
     "exists": "選択された:attributeは、有効ではありません。",


### PR DESCRIPTION
## Summary

- Added missing Japanese translations for the `encoding` validation rule in `php.json` and `php-inline.json`
- This rule was already translated in other locales but was left untranslated in ja, so I translated it to maintain consistency

## Changes

- `php.json` `encoding`: "The :attribute field must be encoded in :encoding." → ":attributeは、:encodingでエンコードされている必要があります。"
- `php-inline.json` `encoding`: "This field must be encoded in :encoding." → ":encodingでエンコードされている必要があります。"

Hope it helps.