### PR TITLE
[source]: Remove download for Nova 4.x

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -106,7 +106,6 @@ jobs:
             fail-fast: true
             matrix:
                 nova:
-                    - { branch: "4.x", version: "4.0" }
                     - { branch: "5.x", version: "5.0" }
         
         name: nova (${{ matrix.nova.branch }})


### PR DESCRIPTION
Removed the '4.x' branch from the nova matrix configuration.