### PR TITLE
[source]: Fix version compare for laravel/passkeys

### DIFF
--- a/src/Plugins/Passkeys/Main.php
+++ b/src/Plugins/Passkeys/Main.php
@@ -10,7 +10,7 @@ class Main extends Plugin
 {
     protected ?string $vendor = 'laravel/passkeys';
 
-    protected string $version = 'dev-main';
+    protected string $version = 'dev-main || ^0.1.0';
 
     public function files(): array
     {


### PR DESCRIPTION
Publisher don't recognize dev version because laravel/passkeys now uses tagged versions