### PR TITLE
[source]: Fix laravel/passkeys semver

### DIFF
--- a/src/Plugins/Passkeys/Main.php
+++ b/src/Plugins/Passkeys/Main.php
@@ -10,7 +10,7 @@ class Main extends Plugin
 {
     protected ?string $vendor = 'laravel/passkeys';
 
-    protected string $version = 'dev-main || ^0.1.0';
+    protected string $version = 'dev-main || ^0.2';
 
     public function files(): array
     {

--- a/src/Plugins/Passkeys/Main.php
+++ b/src/Plugins/Passkeys/Main.php
@@ -10,7 +10,7 @@ class Main extends Plugin
 {
     protected ?string $vendor = 'laravel/passkeys';
 
-    protected string $version = 'dev-main || ^0.2';
+    protected string $version = 'dev-main || 0.*';
 
     public function files(): array
     {


### PR DESCRIPTION
`laravel/passkeys` is at version `0.2.x`.

Therefore
```php
Composer\InstalledVersions::satisfies(new Composer\Semver\VersionParser, 'laravel/passkeys', 'dev-main || ^0.1.0')
```
returns `false` and [`laravel-lang/publisher`](https://github.com/Laravel-Lang/publisher/blob/main/src/Plugins/Plugin.php#L59) is not collecting the translations, because semver.

But
```php
Composer\InstalledVersions::satisfies(new Composer\Semver\VersionParser, 'laravel/passkeys', 'dev-main || ^0.2')
```
returns `true`.