### PR TITLE
[uk]: Use correct country spelling

### DIFF
--- a/locales/uk/json.json
+++ b/locales/uk/json.json
@@ -763,7 +763,7 @@
     "Trinidad and Tobago": "Тринідад і Тобаго",
     "Tunisia": "Туніс",
     "Turkey": "Туреччина",
-    "Turkmenistan": "Туркменистан",
+    "Turkmenistan": "Туркменістан",
     "Turks And Caicos Islands": "Острови Теркс і Кайкос",
     "Turks and Caicos Islands": "Острови Теркс і Кайкос",
     "Tuvalu": "Тувалу",


### PR DESCRIPTION
Heya. In Ukrainian, `и` and `і` carry different sounds
https://uk.wikipedia.org/wiki/Туркменістан