### PR TITLE
[fr]: fix "mot de passé" typo in the incorrect-password message

### DIFF
--- a/locales/fr/json.json
+++ b/locales/fr/json.json
@@ -710,7 +710,7 @@
     "The password is incorrect.": "Le mot de passe est incorrect.",
     "The provided coupon code is invalid.": "Le code de réduction fourni est incorrect.",
     "The provided password does not match your current password.": "Le mot de passe indiqué ne correspond pas à votre mot de passe actuel.",
-    "The provided password was incorrect.": "Le mot de passé indiqué est incorrect.",
+    "The provided password was incorrect.": "Le mot de passe indiqué est incorrect.",
     "The provided two factor authentication code was invalid.": "Le code d'authentification à deux facteurs fourni est incorrect.",
     "The provided two factor recovery code was invalid.": "Le code de récupération fourni pour l'authentification à deux facteurs est incorrect.",
     "The provided VAT number is invalid.": "Le numéro de TVA fourni n'est pas valide.",


### PR DESCRIPTION
`locales/fr/json.json` renders `The provided password was incorrect.` as **"Le mot de passé indiqué est incorrect."**

`passé` is the past participle of *passer*; the noun is `mot de passe`. The two neighbouring keys in the same file already spell it correctly:

- `The password is incorrect.` → "Le mot de pass**e** est incorrect."
- `The provided password does not match your current password.` → "Le mot de pass**e** indiqué ne correspond pas…"

This is the message Fortify returns on a failed password confirmation, so it is user-facing on every French Laravel app using the package.

One character, values only — no keys touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)