### PR TITLE
[fr]: Translated missing value and fixed punctuation

### DIFF
--- a/locales/fr/php.json
+++ b/locales/fr/php.json
@@ -39,7 +39,7 @@
     "doesnt_end_with": "Le champ :attribute ne doit pas finir avec une des valeurs suivantes : :values.",
     "doesnt_start_with": "Le champ :attribute ne doit pas commencer avec une des valeurs suivantes : :values.",
     "email": "Le champ :attribute doit être une adresse e-mail valide.",
-    "encoding": "The :attribute field must be encoded in :encoding.",
+    "encoding": "Le champ :attribute doit être encodé en :encoding.",
     "ends_with": "Le champ :attribute doit se terminer par une des valeurs suivantes : :values",
     "enum": "Le champ :attribute sélectionné est invalide.",
     "exists": "Le champ :attribute sélectionné est invalide.",
@@ -147,5 +147,5 @@
     "uppercase": "Le champ :attribute doit être en majuscules.",
     "url": "Le format de l'URL de :attribute n'est pas valide.",
     "user": "Aucun utilisateur n'a été trouvé avec cette adresse email.",
-    "uuid": "Le champ :attribute doit être un UUID valide"
+    "uuid": "Le champ :attribute doit être un UUID valide."
 }


### PR DESCRIPTION
Added a missing translation for encoding and added a period to uuid, like the other fields have.