### PR TITLE
[hu,ko,lt,sl,sq,sr_Cyrl,sr_Latn,sr_Latn_ME,tr]: Restore corrupted placeholders

### DIFF
--- a/locales/hu/json.json
+++ b/locales/hu/json.json
@@ -384,7 +384,7 @@
     "Liechtenstein": "Liechtenstein",
     "Light": "Fény",
     "Lithuania": "Litvánia",
-    "Load :perPage More": "Betöltése :perpage több",
+    "Load :perPage More": "Betöltése :perPage több",
     "Loading": "Betöltés",
     "Location": "Elhelyezkedés",
     "Log in": "Bejelentkezés",

--- a/locales/ko/json.json
+++ b/locales/ko/json.json
@@ -411,7 +411,7 @@
     "Manage API Tokens": "API 토큰 관리",
     "Manage Role": "역할 관리",
     "Manage Team": "팀 관리",
-    "Managing billing for :billableName": ":BilableName 에 대한 결제 관리",
+    "Managing billing for :billableName": ":billableName 에 대한 결제 관리",
     "March": "3월",
     "Mark all as Read": "모두 읽음으로 표시",
     "Mark all notifications as read": "모든 알림을 읽음으로 표시",

--- a/locales/lt/json.json
+++ b/locales/lt/json.json
@@ -384,7 +384,7 @@
     "Liechtenstein": "Lichtenšteinas",
     "Light": "Šviesa",
     "Lithuania": "Lietuva",
-    "Load :perPage More": "Load :perpage plačiau",
+    "Load :perPage More": "Load :perPage plačiau",
     "Loading": "Įkeliama",
     "Location": "Vieta",
     "Log in": "Prisijungti",

--- a/locales/sl/json.json
+++ b/locales/sl/json.json
@@ -321,7 +321,7 @@
     "Honduras": "Honduras",
     "Hong Kong": "Hongkong",
     "Hungary": "Madžarska",
-    "I agree to the :terms_of_service and :privacy_policy": "Strinjam se s :terms_ of_service in :privacy_policy",
+    "I agree to the :terms_of_service and :privacy_policy": "Strinjam se s :terms_of_service in :privacy_policy",
     "Iceland": "Islandija",
     "ID": "Id",
     "If necessary, you may log out of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.": "Po potrebi se lahko odjavite iz vseh drugih sej brskalnika v vseh svojih napravah. Nekatera vaša nedavna zasedanja so navedena spodaj, vendar ta seznam morda ni izčrpen. Če menite, da je vaš račun ogrožen, morate posodobiti tudi svoje geslo.",

--- a/locales/sq/json.json
+++ b/locales/sq/json.json
@@ -321,7 +321,7 @@
     "Honduras": "Hondurasi",
     "Hong Kong": "Hong Kongu",
     "Hungary": "Hungari",
-    "I agree to the :terms_of_service and :privacy_policy": "Pajtohem me :terms_of_service dhe :privacy_politika",
+    "I agree to the :terms_of_service and :privacy_policy": "Pajtohem me :terms_of_service dhe :privacy_policy",
     "Iceland": "Islanda",
     "ID": "Edhull",
     "If necessary, you may log out of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.": "Nëse është e nevojshme, mund të dilni nga të gjitha seancat e tjera të shfletuesit nëpër të gjitha pajisjet tuaja. Disa nga sesionet tuaja të fundit janë rreshtuar më poshtë; megjithatë, kjo listë mund të mos jetë rraskapitëse. Nëse ndjeni se profili juaj është kompromentuar, duhet të përditësoni gjithashtu fjalëkalimin tuaj.",

--- a/locales/sr_Cyrl/json.json
+++ b/locales/sr_Cyrl/json.json
@@ -321,7 +321,7 @@
     "Honduras": "Хондурас",
     "Hong Kong": "Хонг Конг",
     "Hungary": "Мађарска",
-    "I agree to the :terms_of_service and :privacy_policy": "Слажем се са :terms_оф_сервице и :privacy_полици",
+    "I agree to the :terms_of_service and :privacy_policy": "Слажем се са :terms_of_service и :privacy_policy",
     "Iceland": "Исланд",
     "ID": "ИД",
     "If necessary, you may log out of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.": "Ако је потребно, можете се одјавити са свих осталих сесија прегледача на свим својим уређајима. Неке од ваших најновијих сесија су наведене у наставку; међутим, ова листа можда није исцрпна. Ако сматрате да је ваш налог угрожен, требало би да ажурирате и своју лозинку.",

--- a/locales/sr_Latn/json.json
+++ b/locales/sr_Latn/json.json
@@ -321,7 +321,7 @@
     "Honduras": "HONDURAS",
     "Hong Kong": "HONG KONG",
     "Hungary": "MAĐARSKA",
-    "I agree to the :terms_of_service and :privacy_policy": "SLAŽEM SE SA :terms_OF_SERVICE I :privacy_POLICI",
+    "I agree to the :terms_of_service and :privacy_policy": "SLAŽEM SE SA :terms_of_service I :privacy_policy",
     "Iceland": "ISLAND",
     "ID": "ID",
     "If necessary, you may log out of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.": "AKO JE POTREBNO, MOŽETE SE ODJAVITI SA SVIH OSTALIH SESIJA PREGLEDAČA NA SVIM SVOJIM UREĐAJIMA. NEKE OD VAŠIH NAJNOVIJIH SESIJA SU NAVEDENE U NASTAVKU; MEĐUTIM, OVA LISTA MOŽDA NIJE ISCRPNA. AKO SMATRATE DA JE VAŠ NALOG UGROŽEN, TREBALO BI DA AŽURIRATE I SVOJU LOZINKU.",

--- a/locales/sr_Latn_ME/json.json
+++ b/locales/sr_Latn_ME/json.json
@@ -321,7 +321,7 @@
     "Honduras": "HONDURAS",
     "Hong Kong": "HONG KONG",
     "Hungary": "MAĐARSKA",
-    "I agree to the :terms_of_service and :privacy_policy": "SLAŽEM SE SA :terms_OF_SERVICE I :privacy_POLICI",
+    "I agree to the :terms_of_service and :privacy_policy": "SLAŽEM SE SA :terms_of_service I :privacy_policy",
     "Iceland": "ISLAND",
     "ID": "ID",
     "If necessary, you may log out of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.": "AKO JE POTREBNO, MOŽETE SE ODJAVITI SA SVIH OSTALIH SESIJA PREGLEDAČA NA SVIM SVOJIM UREĐAJIMA. NEKE OD VAŠIH NAJNOVIJIH SESIJA SU NAVEDENE U NASTAVKU; MEĐUTIM, OVA LISTA MOŽDA NIJE ISCRPNA. AKO SMATRATE DA JE VAŠ NALOG UGROŽEN, TREBALO BI DA AŽURIRATE I SVOJU LOZINKU.",

--- a/locales/tr/json.json
+++ b/locales/tr/json.json
@@ -384,7 +384,7 @@
     "Liechtenstein": "Lihtenştayn",
     "Light": "Açık",
     "Lithuania": "Litvanya",
-    "Load :perPage More": ":Perpage daha yükle",
+    "Load :perPage More": ":perPage daha yükle",
     "Loading": "Yükleniyor",
     "Location": "Konum",
     "Log in": "Giriş yap",


### PR DESCRIPTION
Laravel substitutes with `strtr()` against `:name`, `:Name` and `:NAME`. None of
these nine values matches any of those three forms, so the token is printed
literally and the value never reaches the user.

| locale | key | was | cause |
|---|---|---|---|
| `hu` | `Load :perPage More` | `:perpage` | case |
| `lt` | `Load :perPage More` | `:perpage` | case |
| `tr` | `Load :perPage More` | `:Perpage` | case |
| `ko` | `Managing billing for :billableName` | `:BilableName` | typo, one letter |
| `sl` | `I agree to the :terms_of_service and :privacy_policy` | `:terms_ of_service` | stray space |
| `sq` | same | `:privacy_politika` | token translated |
| `sr_Cyrl` | same | `:terms_оф_сервице` `:privacy_полици` | token transliterated |
| `sr_Latn` | same | `:terms_OF_SERVICE` `:privacy_POLICI` | case |
| `sr_Latn_ME` | same | `:terms_OF_SERVICE` `:privacy_POLICI` | case |

**Only the placeholder token is altered.** Not one word of translation is added,
removed or reworded, so none of this needs a native speaker to review — the diff
is nine single-token repairs.

One choice worth stating: the Serbian values keep the placeholder in lower case
rather than matching the surrounding capitals. `:TERMS_OF_SERVICE` is a form
`strtr()` does accept, but it upper-cases the substituted value, and in Jetstream
that value is an anchor tag with a URL inside it.

These nine are the subset that could be fixed mechanically. The same breakage
affects multi-word placeholders in about twenty more locales, and a much larger
problem sits behind them — in `as`, `sa`, `mni_Mtei` and `ckb` every placeholder
was replaced by a literal number. Both are described in the issue rather than
guessed at here.