### PR TITLE
[ja]: fix typo in `locales/ja/json.json`

### DIFF
--- a/locales/ja/json.json
+++ b/locales/ja/json.json
@@ -368,7 +368,7 @@
     "Korea, Republic of": "韓国",
     "Kosovo": "コソボ",
     "Kuwait": "クウェート",
-    "Kyrgyzstan": "キルギス",
+    "Kyrgyzstan": "キルギス共和国",
     "Lao People's Democratic Republic": "ラオス",
     "Last active": "最後のログイン",
     "Last used": "最後に使用された",

--- a/locales/ja/json.json
+++ b/locales/ja/json.json
@@ -368,7 +368,7 @@
     "Korea, Republic of": "韓国",
     "Kosovo": "コソボ",
     "Kuwait": "クウェート",
-    "Kyrgyzstan": "キルギスタン",
+    "Kyrgyzstan": "キルギス",
     "Lao People's Democratic Republic": "ラオス",
     "Last active": "最後のログイン",
     "Last used": "最後に使用された",


### PR DESCRIPTION
## Summary

### Motivation

Updated the country name to "Kyrgyz Republic" to match the official name used in the data source.

[source](https://www.mofa.go.jp/mofaj/area/kyrgyz/data.html#:~:text=%E5%B9%B45%E6%9C%88-,%E5%9B%BD%E5%90%8D%E3%82%92%E3%80%8C%E3%82%AD%E3%83%AB%E3%82%AE%E3%82%B9%E5%85%B1%E5%92%8C%E5%9B%BD%E3%80%8D%E3%81%AB%E5%A4%89%E6%9B%B4,-2005%E5%B9%B44)

### What I have done

```diff
- "キルギスタン"
+ "キルギス"
```

### Test Plans

N/A