### PR TITLE
[fr]: fix typo in `locales/fr/json.json`

### DIFF
--- a/locales/fr/json.json
+++ b/locales/fr/json.json
@@ -710,7 +710,7 @@
     "The password is incorrect.": "Le mot de passe est incorrect.",
     "The provided coupon code is invalid.": "Le code de réduction fourni est incorrect.",
     "The provided password does not match your current password.": "Le mot de passe indiqué ne correspond pas à votre mot de passe actuel.",
-    "The provided password was incorrect.": "Le mot de passé indiqué est incorrect.",
+    "The provided password was incorrect.": "Le mot de passe indiqué est incorrect.",
     "The provided two factor authentication code was invalid.": "Le code d'authentification à deux facteurs fourni est incorrect.",
     "The provided two factor recovery code was invalid.": "Le code de récupération fourni pour l'authentification à deux facteurs est incorrect.",
     "The provided VAT number is invalid.": "Le numéro de TVA fourni n'est pas valide.",


### PR DESCRIPTION
## Summary

### Motivation

`passe` (from *passer*, "to pass") is the correct form in `mot de passe` (password). 
With the acute accent, `passé` means "past", which makes the sentence grammatically incorrect.

### What I have done

```diff
- "The provided password was incorrect.": "Le mot de passé indiqué est incorrect."
+ "The provided password was incorrect.": "Le mot de passe indiqué est incorrect."

### Test Plans

N/A