### PR TITLE
[ja]: wrong translation in `locales/ja/json.json`

### DIFF
--- a/locales/ja/json.json
+++ b/locales/ja/json.json
@@ -445,7 +445,7 @@
     "Nepal": "ネパール",
     "Netherlands": "オランダ",
     "Netherlands Antilles": "オランダ領アンティル",
-    "Nevermind": "やはり",
+    "Nevermind": "気にしない",
     "Nevermind, I'll keep my old plan": "以前のプランを継続します。",
     "New": "新しい",
     "New :resource": "新:resource",


### PR DESCRIPTION
## Summary

Fix the Japanese translation of `Nevermind` in `locales/ja/json.json`.

### Motivation

I think current japanese translation `やはり` ("as expected" / "after all") does not convey the meaning of "Nevermind" (= "it doesn't matter", "forget it"), so I make this PR.

For reference, the French translation uses `Peu importe` ("it doesn't matter"), which matches the intended nuance. 
The new Japanese translation `気にしない` follows the same interpretation.

### What I have done

- `"Nevermind": "やはり"` → `"Nevermind": "気にしない"`

### Test Plans

N/A